### PR TITLE
Grammar: Fix loop expression labels

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -124,13 +124,9 @@
   }
   # Strings
   {
-    'comment': 'Single-quote string'
+    'comment': 'Single-quote string (character literal)'
     'name': 'string.quoted.single.rust'
-    'begin': '\''
-    'end': '\''
-    'patterns': [
-      { 'include': '#escaped_character' }
-    ]
+    'match': '\'([^\'\\\\]|\\\\(x\\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))\''
   }
   {
     'comment': 'Double-quote string'
@@ -216,6 +212,7 @@
   { 'include': '#self' }
   { 'include': '#mut' }
   { 'include': '#box' }
+  { 'include': '#lifetime' }
   { 'include': '#ref_lifetime' }
   # Operators
   {

--- a/test.rs
+++ b/test.rs
@@ -23,10 +23,14 @@ text #![allow(great_algorithms)] text
 text #![!resolve_unexported] text
 text #[deny(silly_comments)] text
 
-text 'single-quote string' text
 text "double-quote string" text
 text "string\nwith\x20escaped\"characters" text
 text "string with // comment /* inside" text
+
+text 'c' text
+text '\n' text
+text '\x20' text
+text '\'' text
 
 text 42f32 text
 text 42e+18 text
@@ -160,3 +164,9 @@ impl MyStruct<'foo> {
   text
 }
 text
+
+'infinity: loop {
+  do_serious_stuff();
+  use_a_letter('Z');
+  break 'infinity;
+}


### PR DESCRIPTION
This fixes highlighting for lifetime labels in `loop` expressions. See [7.2.16](http://static.rust-lang.org/doc/master/rust.html#infinite-loops) in the Rust Reference Manual.
This is the example I included in `test.rs`:

``` rust
'infinity: loop {
  do_serious_stuff();
  use_a_letter('Z');
  break 'infinity;
}
```

The previous grammar definition would erroneously match single-quoted strings in this context, which can cause entire blocks to be highlighted incorrectly.

Most of the problem was single-quoted strings: they do not exist in Rust's grammar. I changed the definition of `string.quoted.single.rust` to match [character literals](http://static.rust-lang.org/doc/master/rust.html#character-and-string-literals) instead, and changed `test.rs` accordingly.
