### PR TITLE
Macro invocations can be macro!(), macro!{} or macro![]

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -239,7 +239,7 @@
   # Function and macro calls
   {
     'comment': 'Invokation of a macro'
-    'match': '\\b([a-zA-Z_][a-zA-Z0-9_]*\\!)\\s*\\('
+    'match': '\\b([a-zA-Z_][a-zA-Z0-9_]*\\!)\\s*[({\\[]'
     'captures': {
       '1': { 'name': 'entity.name.function.macro.rust' }
     }


### PR DESCRIPTION
Rust allows `foo![]` and `foo!{}` form of macro invocations.

This small patch also highlights those forms.
