### PR TITLE
Updated the grammar for changes in Rust.

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -66,7 +66,7 @@
   'kinds': {
     'comment': 'Built-in trait (kind)'
     'name': 'support.type.kind.rust'
-    'match': '\\b(Send|Sized|Copy|Share)\\b'
+    'match': '\\b(Send|Sized|Copy|Share|Drop|Freeze)\\b'
   }
   'self': {
     'comment': 'Self variable'
@@ -201,7 +201,7 @@
   {
     'comment': 'Keyword'
     'name': 'keyword.other.rust'
-    'match': '\\b(crate|extern|mod|let|proc|ref|use)\\b'
+    'match': '\\b(crate|extern|mod|let|proc|ref|use|super)\\b'
   }
   {
     'comment': 'Unsafe code keyword'


### PR DESCRIPTION
These two commits remove some language features that have been taken out of the language in recent months (`~`, `@`, `priv`, `do`) and add a few things that might have been overlooked the first time (`Drop`, `Freeze`, and `super`).
