### PR TITLE
Share has been renamed to Sync.

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -66,7 +66,7 @@
   'kinds': {
     'comment': 'Built-in trait (kind)'
     'name': 'support.type.kind.rust'
-    'match': '\\b(Send|Sized|Copy|Share|Drop|Freeze)\\b'
+    'match': '\\b(Send|Sync|Sized|Copy|Share|Drop|Freeze)\\b'
   }
   'self': {
     'comment': 'Self variable'


### PR DESCRIPTION
I still keep `Share` as it is still in the code.

https://github.com/rust-lang/rust/blob/master/src/libcore/kinds.rs#L24
