### PR TITLE
Use begin/end patterns for single line comments

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -28,12 +28,14 @@
   'line_doc_comment': {
     'comment': 'Single-line documentation comment'
     'name': 'comment.line.documentation.rust'
-    'match': '//[!/][^/].*$'
+    'begin': '//[!/][^/]'
+    'end': '$'
   }
   'line_comment': {
     'comment': 'Single-line comment'
     'name': 'comment.line.double-slash.rust'
-    'match': '//.*$'
+    'begin': '//'
+    'end': '$'
   }
   'escaped_character': {
     'name': 'constant.character.escape.rust'


### PR DESCRIPTION
This allows injection grammars to parse what is in between such as the language-todo grammar.
### Before

![screen shot 2014-11-17 at 5 24 22 pm](https://cloud.githubusercontent.com/assets/671378/5081076/cd2cb992-6e7e-11e4-8006-d6db444ad412.png)
### After

![screen shot 2014-11-17 at 5 24 36 pm](https://cloud.githubusercontent.com/assets/671378/5081072/bc85310a-6e7e-11e4-9c04-bdf4a446bb89.png)

Closes https://github.com/atom/language-todo/issues/13
