### PR TITLE
add whitespace rules per the rust-guidelines

### DIFF
--- a/scoped-properties/rust.cson
+++ b/scoped-properties/rust.cson
@@ -1,3 +1,6 @@
 '.source.rust':
   'editor':
     'commentStart': '// '
+    'tabLength': 4
+    'softTab': true
+    'preferredLineLength': 99


### PR DESCRIPTION
The Rust [guideline](https://github.com/rust-lang/rust-guidelines/blob/master/style/whitespace.md). We might also want to consider adding a dependency to [whitespace](https://github.com/atom/whitespace) so that we can enforce the no trailing whitespace rule.