### PR TITLE
Added highlight for std types in nested generics

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -137,6 +137,7 @@
       { 'include': '#ops' }
       { 'include': '#std_traits' }
       { 'include': '#type_params' }
+      { 'include': '#std_types' }
     ]
   }
 }


### PR DESCRIPTION
This adds highlights for standard types in nested generics

```rust
// now nested Vec will be highlighted
let a: Vec<Vec<i32>> = vec![vec![1,2,3], vec![4,5,6]];
```
      