### PR TITLE
Updated grammar to highlight the identifier on impl blocks

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -328,7 +328,7 @@
   # Type declaration
   {
     'comment': 'Type declaration'
-    'begin': '\\b(enum|struct|trait)\\s+([a-zA-Z_][a-zA-Z0-9_]*)'
+    'begin': '\\b(enum|struct|trait|impl)\\s+([a-zA-Z_][a-zA-Z0-9_]*)'
     'end': '[\\{;]'
     'beginCaptures': {
       '1': { 'name': 'storage.type.rust' }


### PR DESCRIPTION
This is just a simple change to the grammar to support highlighting the identifier (I think thats the correct term) just like how the enum and struct highlight works.

Before:
<img width="151" alt="screen shot 2015-10-26 at 16 12 22" src="https://cloud.githubusercontent.com/assets/1781120/10735104/423a7296-7bfe-11e5-8352-c0b3d5d0c652.png">
After:
<img width="152" alt="screen shot 2015-10-26 at 16 14 14" src="https://cloud.githubusercontent.com/assets/1781120/10735105/42604700-7bfe-11e5-968e-96f5c36cab72.png">
