### PR TITLE
Add snippets for the derive and allow attributes

### DIFF
--- a/snippets/rust.cson
+++ b/snippets/rust.cson
@@ -126,3 +126,12 @@
       \t$2
       }
     '''
+  'derive':
+    'prefix': 'derive'
+    'body': '#[derive(${1:trait})]'
+  'allow':
+    'prefix': 'allow'
+    'body': '#[allow(${1:lint})]'
+  'allow!':
+    'prefix': 'allow!'
+    'body': '#![allow(${1:lint})]'


### PR DESCRIPTION
The added snippets will expand to the following:
`derive` -> `#[derive(trait)]`
`allow` -> `#[allow(lint)]`
`allow!` -> `#![allow(lint)]`

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/zargony/atom-language-rust/58)
<!-- Reviewable:end -->
