### PR TITLE
Provide additional highlighting within function definitions and type declarations

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -81,6 +81,11 @@
     'name': 'storage.modifier.const.rust'
     'match': '\\bconst\\b'
   }
+  'pub': {
+    'comment': 'Visibility modifier'
+    'name': 'storage.modifier.visibility.rust'
+    'match': '\\bpub\\b'
+  }
   'lifetime': {
     'comment': 'Named lifetime'
     'name': 'storage.modifier.lifetime.rust'
@@ -220,11 +225,6 @@
     'match': '\\bstatic\\b'
   }
   {
-    'comment': 'Visibility modifier'
-    'name': 'storage.modifier.visibility.rust'
-    'match': '\\bpub\\b'
-  }
-  {
     'comment': 'Boolean constant'
     'name': 'constant.language.boolean.rust'
     'match': '\\b(true|false)\\b'
@@ -251,6 +251,7 @@
   { 'include': '#lifetime' }
   { 'include': '#ref_lifetime' }
   { 'include': '#const' }
+  { 'include': '#pub' }
   # Operators
   {
     'comment': 'Operator'
@@ -342,6 +343,8 @@
       { 'include': '#traits' }
       { 'include': '#std_traits' }
       { 'include': '#type_params' }
+      { 'include': '#core_types' }
+      { 'include': '#pub' }
     ]
   }
   # Type alias

--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -76,6 +76,11 @@
     'name': 'storage.modifier.box.rust'
     'match': '\\bbox\\b'
   }
+  'const': {
+    'comment': 'Const storage modifier'
+    'name': 'storage.modifier.const.rust'
+    'match': '\\bconst\\b'
+  }
   'lifetime': {
     'comment': 'Named lifetime'
     'name': 'storage.modifier.lifetime.rust'
@@ -215,11 +220,6 @@
     'match': '\\bstatic\\b'
   }
   {
-    'comment': 'Const storage modifier'
-    'name': 'storage.modifier.const.rust'
-    'match': '\\bconst\\b'
-  }
-  {
     'comment': 'Visibility modifier'
     'name': 'storage.modifier.visibility.rust'
     'match': '\\bpub\\b'
@@ -250,6 +250,7 @@
   { 'include': '#box' }
   { 'include': '#lifetime' }
   { 'include': '#ref_lifetime' }
+  { 'include': '#const' }
   # Operators
   {
     'comment': 'Operator'
@@ -323,6 +324,7 @@
       { 'include': '#std_types' }
       { 'include': '#std_traits' }
       { 'include': '#type_params' }
+      { 'include': '#const' }
     ]
   }
   # Type declaration

--- a/test.rs
+++ b/test.rs
@@ -212,3 +212,6 @@ if x == 1 { }
 fn foo(bar: *const i32) {
     let _ = 1234 as *const u32;
 }
+
+// Keywords and known types in wrapper structs (#56)
+pub struct Foobar(pub Option<bool>);

--- a/test.rs
+++ b/test.rs
@@ -207,3 +207,8 @@ let x: Vec<Vec<u8>> = Vec::new();
 // Correct detection of == (#40)
 struct Foo { x: i32 }
 if x == 1 { }
+
+// const function parameter (#52)
+fn foo(bar: *const i32) {
+    let _ = 1234 as *const u32;
+}


### PR DESCRIPTION
Hello.

I've got very limited experience with writing grammar match rules so please be gentle. I made some changes to fix some issues (#52, #56) that I saw were still outstanding. I'm using this as an opportunity to learn more about the Rust language too (I'm a complete newbie, but loving it so far), and would be happy to continue contributing. :-)

I didn't see any test specs so I simply updated the `test.rs` file with cases my changes should have resolved.

![preview](https://cloud.githubusercontent.com/assets/2031402/12013299/89b935d6-ad4e-11e5-87c3-6fa10a6fe2f2.png)
