### PR TITLE
Recognize tuple structs correctly

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -346,7 +346,7 @@
   {
     'comment': 'Type declaration'
     'begin': '\\b(enum|struct|trait)\\s+([a-zA-Z_][a-zA-Z0-9_]*)'
-    'end': '[\\{;]'
+    'end': '[\\{\\(;]'
     'beginCaptures': {
       '1': { 'name': 'storage.type.rust' }
       '2': { 'name': 'entity.name.type.rust' }


### PR DESCRIPTION
They now look like this:
![tuplestruct](https://cloud.githubusercontent.com/assets/1786438/13045191/4914941c-d3d2-11e5-9bc2-ff3cd7b155cc.png)

Previously, the `pub` before `BasicBlockRef` wasn't highlighted.