### PR TITLE
Fixed an error when a comment is in an attribute.

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -177,6 +177,10 @@
     'end': '\\]'
     'patterns': [
       { 'include': '#string_literal' }
+      { 'include': '#block_doc_comment' }
+      { 'include': '#block_comment' }
+      { 'include': '#line_doc_comment' }
+      { 'include': '#line_comment' }
     ]
   }
   # Strings


### PR DESCRIPTION
Maintainers of Visual Studio Code asked me to open this PR.
The PR in Visual Studio Code's repository: https://github.com/Microsoft/vscode/pull/19574

It fixes the case:
```rust
#[
//
/* */
derive(Debug)]
struct D {}
```