### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -39,7 +39,7 @@
   }
   'escaped_character': {
     'name': 'constant.character.escape.rust'
-    'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+    'match': '\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
   }
   'string_literal': {
     'comment': 'Double-quote string literal'
@@ -221,7 +221,7 @@
   {
     'comment': 'Single-quote string literal (character)'
     'name': 'string.quoted.single.rust'
-    'match': 'b?\'([^\'\\\\]|\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))\''
+    'match': 'b?\'([^\'\\\\]|\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))\''
   }
   { 'include': '#string_literal' }
   { 'include': '#raw_string_literal' }


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.