### PR TITLE
Lex Type, Identifiers in additional contexts

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -414,6 +414,8 @@
         'match': '\bfn\b'
         'name': 'keyword.other.fn.rust'
       }
+      { 'include': '#type' }
+      { 'include': '#identifier' }
     ]
   }
   # Type declaration

--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -147,6 +147,11 @@
     'name': 'entity.name.type.rust'
     'match': '\\b([A-Z][_A-Za-z0-9]*|_[_A-Za-z0-9]+)\\b'
   }
+  'identifier': {
+    'comment': 'Any identifier not otherwise specified'
+    'name': 'variable.other.rust'
+    'match': '\\b([A-Za-z][_A-Za-z0-9]*|_[_A-Za-z0-9]+)\\b'
+  }
   'type_params': {
     'comment': 'Type parameters'
     'name': 'meta.type_params.rust'
@@ -215,6 +220,7 @@
       { 'include': '#block_comment' }
       { 'include': '#line_doc_comment' }
       { 'include': '#line_comment' }
+      { 'include': '#type' }
     ]
   }
   # Strings

--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -462,4 +462,6 @@
       { 'include': '#type_params' }
     ]
   }
+  { 'include': '#type' }
+  { 'include': '#identifier' }
 ]

--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -145,7 +145,7 @@
   'type': {
     'comment': 'A type'
     'name': 'entity.name.type.rust'
-    'match': '\\b([A-Za-z][_A-Za-z0-9]*|_[_A-Za-z0-9]+)\\b'
+    'match': '\\b([A-Z][_A-Za-z0-9]*|_[_A-Za-z0-9]+)\\b'
   }
   'type_params': {
     'comment': 'Type parameters'
@@ -164,7 +164,7 @@
       { 'include': '#std_types' }
       { 'include': '#std_traits' }
       { 'include': '#type_params' }
-      # { 'include': '#type' }
+      { 'include': '#type' }
     ]
   }
 }


### PR DESCRIPTION
So I've made a couple enhancements that noticeably improve syntax highlighting, particularly for VSCode:

- Modified the `type` rule to match only those lexemes which start with an ASCII capital letter (e.g. `Vertex` but not `vertex`, `PartialEq` but not `partialEq`).
- Added an `identifier` rule which accepts everything that `type` used to accept, but is matched later so as not to conflict
- Allow `type`s and `identifier`s to be matched in `attribute`s, function definitions, and elsewhere (not otherwise specified)

Hope this is cool.