### PR TITLE
Add unicode escapes, allow non-ASCII identifiers & others improvements

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -39,12 +39,26 @@
   }
   'escaped_character': {
     'name': 'constant.character.escape.rust'
-    'match': '\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+    'match': '\\\\([trn0\'\"\\\\]|x[0-9A-Fa-f]{2}|$)'
+  }
+  'unicode_escaped_character': {
+    'name': 'constant.character.escape.unicode.rust'
+    'match': '\\\\u\\{([0-9A-Fa-f]_*){1,6}\\}'
   }
   'string_literal': {
     'comment': 'Double-quote string literal'
     'name': 'string.quoted.double.rust'
-    'begin': 'b?"'
+    'begin': '"'
+    'end': '"'
+    'patterns': [
+      { 'include': '#escaped_character' }
+      { 'include': '#unicode_escaped_character' }
+    ]
+  }
+  'byte_string_literal': {
+    'comment': 'Double-quote byte string literal'
+    'name': 'string.byte.quoted.double.rust'
+    'begin': 'b"'
     'end': '"'
     'patterns': [
       { 'include': '#escaped_character' }
@@ -59,7 +73,7 @@
   'sigils': {
     'comment': 'Sigil'
     'name': 'keyword.operator.sigil.rust'
-    'match': '[&*](?=[a-zA-Z0-9_\\(\\[\\|\\"]+)'
+    'match': '[&*](?=[a-zA-Z0-9_\\(\\[\\|\\"\\x80-\\xFF]+)'
   }
   'self': {
     'comment': 'Self variable'
@@ -99,14 +113,14 @@
   'lifetime': {
     'comment': 'Named lifetime'
     'name': 'storage.modifier.lifetime.rust'
-    'match': '\'([a-zA-Z_][a-zA-Z0-9_]*)\\b'
+    'match': '\'([a-zA-Z_\\x80-\\xFF][a-zA-Z0-9_\\x80-\\xFF]*)\\b'
     'captures': {
       '1': { 'name': 'entity.name.lifetime.rust' }
     }
   }
   'ref_lifetime': {
     'comment': 'Reference with named lifetime'
-    'match': '&(\'([a-zA-Z_][a-zA-Z0-9_]*))\\b'
+    'match': '&(\'([a-zA-Z_\\x80-\\xFF][a-zA-Z0-9_\\x80-\\xFF]*))\\b'
     'captures': {
       '1': { 'name': 'storage.modifier.lifetime.rust' }
       '2': { 'name': 'entity.name.lifetime.rust' }
@@ -145,7 +159,7 @@
   'type': {
     'comment': 'A type'
     'name': 'entity.name.type.rust'
-    'match': '\\b([A-Za-z][_A-Za-z0-9]*|_[_A-Za-z0-9]+)\\b'
+    'match': '\\b([A-Za-z\\x80-\\xFF][_A-Za-z0-9\\x80-\\xFF]*|_[_A-Za-z0-9\\x80-\\xFF]+)\\b'
   }
   'type_params': {
     'comment': 'Type parameters'
@@ -211,6 +225,7 @@
     'end': '\\]'
     'patterns': [
       { 'include': '#string_literal' }
+      { 'include': '#byte_string_literal' }
       { 'include': '#block_doc_comment' }
       { 'include': '#block_comment' }
       { 'include': '#line_doc_comment' }
@@ -221,9 +236,15 @@
   {
     'comment': 'Single-quote string literal (character)'
     'name': 'string.quoted.single.rust'
-    'match': 'b?\'([^\'\\\\]|\\\\(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.))\''
+    'match': '\'([^\'\\\\]|\\\\([trn0\'\"\\\\]|x[0-9A-Fa-f]{2}|u\\{([0-9A-Fa-f]_*){1,6}\\}))\''
+  }
+  {
+    'comment': 'Single-quote byte string literal (character)'
+    'name': 'string.byte.quoted.single.rust'
+    'match': 'b\'([^\'\\\\]|\\\\([trn0\'\"\\\\]|x[0-9A-Fa-f]{2}))\''
   }
   { 'include': '#string_literal' }
+  { 'include': '#byte_string_literal' }
   { 'include': '#raw_string_literal' }
   # Numbers
   {
@@ -244,22 +265,22 @@
   {
     'comment': 'Integer literal (decimal)'
     'name': 'constant.numeric.integer.decimal.rust'
-    'match': '\\b[0-9][0-9_]*([ui](8|16|32|64|128|s|size))?\\b'
+    'match': '\\b[0-9][0-9_]*([ui](8|16|32|64|128|size))?\\b'
   }
   {
     'comment': 'Integer literal (hexadecimal)'
     'name': 'constant.numeric.integer.hexadecimal.rust'
-    'match': '\\b0x[a-fA-F0-9_]+([ui](8|16|32|64|128|s|size))?\\b'
+    'match': '\\b0x[a-fA-F0-9_]+([ui](8|16|32|64|128|size))?\\b'
   }
   {
     'comment': 'Integer literal (octal)'
     'name': 'constant.numeric.integer.octal.rust'
-    'match': '\\b0o[0-7_]+([ui](8|16|32|64|128|s|size))?\\b'
+    'match': '\\b0o[0-7_]+([ui](8|16|32|64|128|size))?\\b'
   }
   {
     'comment': 'Integer literal (binary)'
     'name': 'constant.numeric.integer.binary.rust'
-    'match': '\\b0b[01_]+([ui](8|16|32|64|128|s|size))?\\b'
+    'match': '\\b0b[01_]+([ui](8|16|32|64|128|size))?\\b'
   }
   # Language
   {
@@ -354,21 +375,21 @@
   # Function and macro calls
   {
     'comment': 'Invokation of a macro'
-    'match': '\\b([a-zA-Z_][a-zA-Z0-9_]*\\!)\\s*[({\\[]'
+    'match': '\\b([a-zA-Z_\\x80-\\xFF][a-zA-Z0-9_\\x80-\\xFF]*\\!)\\s*[({\\[]'
     'captures': {
       '1': { 'name': 'entity.name.function.macro.rust' }
     }
   }
   {
     'comment': 'Function call'
-    'match': '\\b([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)\\s*\\('
+    'match': '\\b([A-Za-z\\x80-\\xFF][A-Za-z0-9_\\x80-\\xFF]*|_[A-Za-z0-9_\\x80-\\xFF]+)\\s*\\('
     'captures': {
       '1': { 'name': 'entity.name.function.rust' }
     }
   }
   {
     'comment': 'Function call with type parameters'
-    'begin': '\\b([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)\\s*(::)(?=\\s*<.*>\\s*\\()'
+    'begin': '\\b([A-Za-z\\x80-\\xFF][A-Za-z0-9_\\x80-\\xFF]*|_[A-Za-z0-9_\\x80-\\xFF]+)\\s*(::)(?=\\s*<.*>\\s*\\()'
     'end': '\\('
     'captures': {
       '1': { 'name': 'entity.name.function.rust' }
@@ -381,7 +402,7 @@
   # Function definition
   {
     'comment': 'Function definition'
-    'begin': '\\b(fn)\\s+([A-Za-z][A-Za-z0-9_]*|_[A-Za-z0-9_]+)'
+    'begin': '\\b(fn)\\s+([A-Za-z\\x80-\\xFF][A-Za-z0-9_\\x80-\\xFF]*|_[A-Za-z0-9_\\x80-\\xFF]+)'
     'end': '[\\{;]'
     'beginCaptures': {
       '1': { 'name': 'keyword.other.fn.rust' }
@@ -413,7 +434,7 @@
   # Type declaration
   {
     'comment': 'Type declaration'
-    'begin': '\\b(enum|struct|trait|union)\\s+([a-zA-Z_][a-zA-Z0-9_]*)'
+    'begin': '\\b(enum|struct|trait|union)\\s+([a-zA-Z_\\x80-\\xFF][a-zA-Z0-9_\\x80-\\xFF]*)'
     'end': '[\\{\\(;]'
     'beginCaptures': {
       '1': { 'name': 'storage.type.rust' }
@@ -433,7 +454,7 @@
   # Type alias
   {
     'comment': 'Type alias'
-    'begin': '\\b(type)\\s+([a-zA-Z_][a-zA-Z0-9_]*)'
+    'begin': '\\b(type)\\s+([a-zA-Z_\\x80-\\xFF][a-zA-Z0-9_\\x80-\\xFF]*)'
     'end': ';'
     'beginCaptures': {
       '1': { 'name': 'storage.type.rust' }

--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -73,7 +73,7 @@
   'sigils': {
     'comment': 'Sigil'
     'name': 'keyword.operator.sigil.rust'
-    'match': '[&*](?=[a-zA-Z0-9_\\(\\[\\|\\"\\x80-\\xFF]+)'
+    'match': '[&*~@](?=[a-zA-Z0-9_\\(\\[\\|\\"\\x80-\\xFF]+)'
   }
   'self': {
     'comment': 'Self variable'

--- a/spec/rust-spec.coffee
+++ b/spec/rust-spec.coffee
@@ -103,11 +103,11 @@ describe 'Rust grammar', ->
     {tokens} = grammar.tokenizeLine('text "string\\nwith\\x20escaped\\"characters" text')
     expect(tokens[0]).toEqual value: 'text ', scopes: ['source.rust']
     expect(tokens[2]).toEqual value: 'string', scopes: ['source.rust', 'string.quoted.double.rust']
-    expect(tokens[3]).toEqual value: '\\n', scopes: ['source.rust', 'string.quoted.double.rust', 'constant.character.escape.rust']
+    expect(tokens[3]).toEqual value: '\\n', scopes: ['source.rust', 'string.quoted.double.rust', 'constant.character.escape.rust', 'constant.character.escape.unicode.rust']
     expect(tokens[4]).toEqual value: 'with', scopes: ['source.rust', 'string.quoted.double.rust']
-    expect(tokens[5]).toEqual value: '\\x20', scopes: ['source.rust', 'string.quoted.double.rust', 'constant.character.escape.rust']
+    expect(tokens[5]).toEqual value: '\\x20', scopes: ['source.rust', 'string.quoted.double.rust', 'constant.character.escape.rust', 'constant.character.escape.unicode.rust']
     expect(tokens[6]).toEqual value: 'escaped', scopes: ['source.rust', 'string.quoted.double.rust']
-    expect(tokens[7]).toEqual value: '\\"', scopes: ['source.rust', 'string.quoted.double.rust', 'constant.character.escape.rust']
+    expect(tokens[7]).toEqual value: '\\"', scopes: ['source.rust', 'string.quoted.double.rust', 'constant.character.escape.rust', 'constant.character.escape.unicode.rust']
     expect(tokens[8]).toEqual value: 'characters', scopes: ['source.rust', 'string.quoted.double.rust']
     expect(tokens[10]).toEqual value: ' text', scopes: ['source.rust']
 
@@ -139,7 +139,7 @@ describe 'Rust grammar', ->
   it 'tokenizes byte strings', ->
     {tokens} = grammar.tokenizeLine('text b"This is a bytestring" text')
     expect(tokens[0]).toEqual value: 'text ', scopes: ['source.rust']
-    expect(tokens[2]).toEqual value: 'This is a bytestring', scopes: ['source.rust', 'string.quoted.double.rust']
+    expect(tokens[2]).toEqual value: 'This is a bytestring', scopes: ['source.rust', 'string.byte.quoted.double.rust']
     expect(tokens[4]).toEqual value: ' text', scopes: ['source.rust']
 
   it 'tokenizes raw byte strings', ->
@@ -170,13 +170,13 @@ describe 'Rust grammar', ->
   it 'tokenizes bytes character', ->
     {tokens} = grammar.tokenizeLine('text b\'b\' text')
     expect(tokens[0]).toEqual value: 'text ', scopes: ['source.rust']
-    expect(tokens[1]).toEqual value: 'b\'b\'', scopes: ['source.rust', 'string.quoted.single.rust']
+    expect(tokens[1]).toEqual value: 'b\'b\'', scopes: ['source.rust', 'string.byte.quoted.single.rust']
     expect(tokens[2]).toEqual value: ' text', scopes: ['source.rust']
 
   it 'tokenizes escaped bytes characters', ->
     {tokens} = grammar.tokenizeLine('text b\'\\x20\' text')
     expect(tokens[0]).toEqual value: 'text ', scopes: ['source.rust']
-    expect(tokens[1]).toEqual value: 'b\'\\x20\'', scopes: ['source.rust', 'string.quoted.single.rust']
+    expect(tokens[1]).toEqual value: 'b\'\\x20\'', scopes: ['source.rust', 'string.byte.quoted.single.rust']
     expect(tokens[2]).toEqual value: ' text', scopes: ['source.rust']
 
   #

--- a/spec/rust-spec.coffee
+++ b/spec/rust-spec.coffee
@@ -327,9 +327,11 @@ describe 'Rust grammar', ->
     expect(tokens[2]).toEqual value: ' text', scopes: ['source.rust']
 
   it 'tokenizes sigils', ->
-    {tokens} = grammar.tokenizeLine('*var &var')
+    {tokens} = grammar.tokenizeLine('*var &var ~var @var')
     expect(tokens[0]).toEqual value: '*', scopes: ['source.rust', 'keyword.operator.sigil.rust']
     expect(tokens[2]).toEqual value: '&', scopes: ['source.rust', 'keyword.operator.sigil.rust']
+    expect(tokens[3]).toEqual value: '~', scopes: ['source.rust', 'keyword.operator.sigil.rust']
+    expect(tokens[4]).toEqual value: '@', scopes: ['source.rust', 'keyword.operator.sigil.rust']
 
   #
   # Core


### PR DESCRIPTION
**Changes:**
* Fix escape characters. The detection of escapes is very general, I have replaced it with the specific escapes supported by Rust [1].
* Add unicode escapes: `\u{NNNNNN}` [2]. However, the bytes and byte strings don't allow unicode escapes [4], therefore, the unicode escape is placed in a different object and new objects are created for byte strings and byte characters.
* Fix: remove obsolete integer suffixes `is` & `us` (these were depreciated by `isize` & `usize` [5]).
* Allow non-ASCII characters in identifiers (in the Rust parser, an identifier is: `[a-zA-Z\x80-\xff_][a-zA-Z0-9\x80-\xff_]*` [6]). This affects Lifetimes, Macros, functions and types (to do this, I basically added `\\x80-\\xFF`, and it works fine. But the POSIX character class `[:ascii:]` can also be used, for example: `(?:[a-zA-Z0-9_]|[^[:ascii:]])` ).
* Add missing sigils: `~` `@`

**NOTE:** The use of non-ASCII characters in identifiers is a feature of Rust, however these have some issues and aren't currently fully supported (see ref. [7]). 

If you want to make some change, correction, or undo something, I have no problem.

**References:**
* [1] Escapes supported in Rust (Rust Docs): https://doc.rust-lang.org/std/primitive.char.html#method.escape_default
* [2] Unicode escapes (Rust RFCs): https://github.com/nox/rust-rfcs/blob/master/text/0446-es6-unicode-escapes.md
* [4] Do not accept unicode escape characters in byte strings or as byte: https://github.com/rust-lang/rust/pull/23625
* [5] Change suffixes to `isize` and `usize`: https://github.com/rust-lang/rust/issues/22496
* [6] Identifiers in Rust parser (see line 42): https://github.com/rust-lang/rust/blob/master/src/grammar/lexer.l
* [7] Issue for non-ASCII identifiers: https://github.com/rust-lang/rust/issues/28979
* [8] Sigil reference: https://github.com/rust-lang/rust-wiki-backup/blob/master/Sigil-reference.md

**Some Sources:**
* Rust in Vim: https://github.com/rust-lang/rust.vim/blob/master/syntax/rust.vim
* Rust in ACE: https://github.com/ajaxorg/ace/blob/master/lib/ace/mode/rust_highlight_rules.js