### PR TITLE
Add dyn keyword support

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -71,6 +71,11 @@
     'name': 'storage.modifier.mut.rust'
     'match': '\\bmut\\b'
   }
+  'dyn': {
+    'comment': 'Dynamic modifier'
+    'name': 'storage.modifier.mut.rust'
+    'match': '\\bmut\\b'
+  }
   'box': {
     'comment': 'Box storage modifier'
     'name': 'storage.modifier.box.rust'
@@ -157,6 +162,7 @@
       { 'include': '#line_comment' }
       { 'include': '#sigils' }
       { 'include': '#mut' }
+      { 'include': '#dyn' }
       { 'include': '#lifetime' }
       { 'include': '#core_types' }
       { 'include': '#core_marker' }
@@ -291,6 +297,7 @@
   { 'include': '#sigils' }
   { 'include': '#self' }
   { 'include': '#mut' }
+  { 'include': '#dyn' }
   { 'include': '#box' }
   { 'include': '#lifetime' }
   { 'include': '#ref_lifetime' }
@@ -393,6 +400,7 @@
       { 'include': '#sigils' }
       { 'include': '#self' }
       { 'include': '#mut' }
+      { 'include': '#dyn' }
       { 'include': '#ref_lifetime' }
       { 'include': '#core_types' }
       { 'include': '#core_marker' }
@@ -444,6 +452,7 @@
       { 'include': '#line_comment' }
       { 'include': '#sigils' }
       { 'include': '#mut' }
+      { 'include': '#dyn' }
       { 'include': '#lifetime' }
       { 'include': '#ref_lifetime' }
       { 'include': '#core_types' }

--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -74,7 +74,12 @@
   'dyn': {
     'comment': 'Dynamic modifier'
     'name': 'storage.modifier.mut.rust'
-    'match': '\\bmut\\b'
+    'match': '\\bdyn\\b'
+  }
+  'impl': {
+    'comment': 'Existential type modifier'
+    'name': 'storage.modifier.impl.rust'
+    'match': '\\bimpl\\b'
   }
   'box': {
     'comment': 'Box storage modifier'
@@ -163,6 +168,7 @@
       { 'include': '#sigils' }
       { 'include': '#mut' }
       { 'include': '#dyn' }
+      { 'include': '#impl' }
       { 'include': '#lifetime' }
       { 'include': '#core_types' }
       { 'include': '#core_marker' }
@@ -189,6 +195,7 @@
         { 'include': '#line_comment' }
         { 'include': '#sigils' }
         { 'include': '#mut' }
+        { 'include': '#dyn' }
         { 'include': '#ref_lifetime' }
         { 'include': '#core_types' }
         { 'include': '#core_marker' }
@@ -298,6 +305,7 @@
   { 'include': '#self' }
   { 'include': '#mut' }
   { 'include': '#dyn' }
+  { 'include': '#impl' }
   { 'include': '#box' }
   { 'include': '#lifetime' }
   { 'include': '#ref_lifetime' }
@@ -401,6 +409,7 @@
       { 'include': '#self' }
       { 'include': '#mut' }
       { 'include': '#dyn' }
+      { 'include': '#impl' }
       { 'include': '#ref_lifetime' }
       { 'include': '#core_types' }
       { 'include': '#core_marker' }
@@ -453,6 +462,7 @@
       { 'include': '#sigils' }
       { 'include': '#mut' }
       { 'include': '#dyn' }
+      { 'include': '#impl' }
       { 'include': '#lifetime' }
       { 'include': '#ref_lifetime' }
       { 'include': '#core_types' }

--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -73,7 +73,7 @@
   }
   'dyn': {
     'comment': 'Dynamic modifier'
-    'name': 'storage.modifier.mut.rust'
+    'name': 'storage.modifier.dyn.rust'
     'match': '\\bdyn\\b'
   }
   'impl': {

--- a/spec/rust-spec.coffee
+++ b/spec/rust-spec.coffee
@@ -763,3 +763,75 @@ describe 'Rust grammar', ->
     expect(tokens[0][5]).toEqual value: 'a', scopes: ['source.rust', 'meta.type_params.rust', 'storage.modifier.lifetime.rust', 'entity.name.lifetime.rust']
     expect(tokens[0][13]).toEqual value: "'", scopes: ['source.rust', 'meta.type_params.rust', 'storage.modifier.lifetime.rust']
     expect(tokens[0][14]).toEqual value: 'a', scopes: ['source.rust', 'meta.type_params.rust', 'storage.modifier.lifetime.rust', 'entity.name.lifetime.rust']
+
+  #
+  # impl type modifier
+  #
+
+  it 'tokenizes impl type modifier in return type position', ->
+    tokens = grammar.tokenizeLines("fn foo() -> impl Iterator<Item=u8> { unimplemented!() }")
+    expect(tokens[0][4]).toEqual value: "impl", scopes:['source.rust', 'storage.modifier.impl.rust']
+
+  it 'tokenize impl type modifier in argument position', ->
+    tokens = grammar.tokenizeLines("fn foo(i: impl Iterator<Item=u8>) { unimplemented!() }")
+    expect(tokens[0][4]).toEqual value: "impl", scopes:['source.rust', 'storage.modifier.impl.rust']
+
+  it 'tokenize impl type modifier in parameter position in impl blocks', ->
+    tokens = grammar.tokenizeLines('''
+      impl Foo {
+        fn foo(i: impl Iterator<Item=u8>) { unimplemented!() }
+      }
+    ''')
+    expect(tokens[1][5]).toEqual value: "impl", scopes:['source.rust', 'storage.modifier.impl.rust']
+
+  it 'tokenize impl type modifier in return position in impl blocks', ->
+    tokens = grammar.tokenizeLines('''
+      impl Foo {
+        fn foo() -> impl Iterator<Item=u8> { unimplemented!() }
+      }
+    ''')
+    expect(tokens[1][5]).toEqual value: "impl", scopes:['source.rust', 'storage.modifier.impl.rust']
+
+  #
+  # dyn type modifier
+  #
+
+  it 'tokenizes dyn type modifier in return type position', ->
+    tokens = grammar.tokenizeLines("fn foo() -> &'static dyn Iterator<Item=u8> { unimplemented!() }")
+    expect(tokens[0][8]).toEqual value: "dyn", scopes:['source.rust', 'storage.modifier.dyn.rust']
+
+  it 'tokenizes dyn type modifier in return type position, as type parameter', ->
+    tokens = grammar.tokenizeLines("fn foo() -> Box<dyn Debug> { unimplemented!() }")
+    expect(tokens[0][6]).toEqual value: "dyn", scopes:['source.rust', 'meta.type_params.rust', 'storage.modifier.dyn.rust']
+
+  it 'tokenize impl type modifier in argument position', ->
+    tokens = grammar.tokenizeLines("fn foo(i: &dyn Iterator<Item=u8>) { unimplemented!() }")
+    expect(tokens[0][5]).toEqual value: "dyn", scopes:['source.rust', 'storage.modifier.dyn.rust']
+
+  it 'tokenizes dyn type modifier parameter type position, as type parameter', ->
+    tokens = grammar.tokenizeLines("fn foo(b: Box<dyn Debug>) { unimplemented!() }")
+    expect(tokens[0][6]).toEqual value: "dyn", scopes:['source.rust', 'meta.type_params.rust', 'storage.modifier.dyn.rust']
+
+  it 'tokenize dyn type modifier in parameter position in impl blocks', ->
+    tokens = grammar.tokenizeLines('''
+      impl Foo {
+        fn foo(i: &dyn Iterator<Item=u8>) { unimplemented!() }
+      }
+    ''')
+    expect(tokens[1][6]).toEqual value: "dyn", scopes:['source.rust', 'storage.modifier.dyn.rust']
+
+  it 'tokenize dyn type modifier in return position in impl blocks', ->
+    tokens = grammar.tokenizeLines('''
+      impl Foo {
+        fn foo() -> &'static dyn Iterator<Item=u8> { unimplemented!() }
+      }
+    ''')
+    expect(tokens[1][9]).toEqual value: "dyn", scopes:['source.rust', 'storage.modifier.dyn.rust']
+
+  it 'tokenizes dyn type modifier variable type declaration', ->
+    tokens = grammar.tokenizeLines("fn foo() { let bar : &dyn Debug = &32; }")
+    expect(tokens[0][9]).toEqual value: "dyn", scopes:['source.rust', 'storage.modifier.dyn.rust']
+
+  it 'tokenizes dyn type modifier variable type declaration, as type parameter', ->
+    tokens = grammar.tokenizeLines("fn foo() { let b: Box<dyn Debug> = Box::new(32); }")
+    expect(tokens[0][10]).toEqual value: "dyn", scopes:['source.rust', 'storage.modifier.dyn.rust']


### PR DESCRIPTION
In rust 1.27 a new "dyn" keyword was introduced:
https://blog.rust-lang.org/2018/06/21/Rust-1.27.html#dyn-trait
This keyword is used in similar places as the mut keyword.