### PR TITLE
Escape \b in keyword.other.fn.rust

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -422,7 +422,7 @@
       { 'include': '#unsafe' }
       {
         'comment': 'Function arguments'
-        'match': '\bfn\b'
+        'match': '\\bfn\\b'
         'name': 'keyword.other.fn.rust'
       }
     ]


### PR DESCRIPTION
I'm trying to open this file and convert it to json, this seemed to be a bug (?)

The cson parser I'm using converts that string to `\x08fn\x08`