### PR TITLE
update reserved keywords

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -298,7 +298,7 @@
   {
     'comment': 'Reserved keyword'
     'name': 'invalid.deprecated.rust'
-    'match': '\\b(abstract|alignof|become|do|final|macro|offsetof|override|priv|proc|pure|sizeof|typeof|virtual|yield)\\b'
+    'match': '\\b(abstract|become|do|final|macro|override|priv|typeof|unsized|virtual|yield)\\b'
   }
   { 'include': '#unsafe' }
   { 'include': '#sigils' }

--- a/spec/rust-spec.coffee
+++ b/spec/rust-spec.coffee
@@ -308,7 +308,7 @@ describe 'Rust grammar', ->
       expect(tokens[2]).toEqual value: ' text', scopes: ['source.rust']
 
   it 'tokenizes reserved keywords', ->
-    for t in ['abstract', 'alignof', 'become', 'do', 'final', 'macro', 'offsetof', 'override', 'priv', 'proc', 'pure', 'sizeof', 'typeof', 'virtual', 'yield']
+    for t in ['abstract', 'become', 'do', 'final', 'macro', 'override', 'priv', 'typeof', 'unsized', 'virtual', 'yield']
       {tokens} = grammar.tokenizeLine("text #{t} text")
       expect(tokens[0]).toEqual value: 'text ', scopes: ['source.rust']
       expect(tokens[1]).toEqual value: t, scopes: ['source.rust', 'invalid.deprecated.rust']


### PR DESCRIPTION
Updates reserved keywords. Most are removals. For instance, `proc` was removed [here](https://github.com/rust-lang/rust/pull/49699)

List: https://doc.rust-lang.org/reference/keywords.html#reserved-keywords

Proof: https://play.rust-lang.org/?version=stable&mode=debug&edition=2018&gist=16ceeadb190d1804eab3cf5e8439c1bc (keywords are outdated at the playground as well, but the point is it compiles)