### PR TITLE
Allow raw string literals in directives

### DIFF
--- a/grammars/rust.cson
+++ b/grammars/rust.cson
@@ -224,6 +224,7 @@
     'end': '\\]'
     'patterns': [
       { 'include': '#string_literal' }
+      ( 'include': '#raw_string_literal' }
       { 'include': '#block_doc_comment' }
       { 'include': '#block_comment' }
       { 'include': '#line_doc_comment' }


### PR DESCRIPTION
This is legal rust but breaks my pretty highlighting